### PR TITLE
GDE-1373 - No operation on same command

### DIFF
--- a/src/test/java/com/pkb/unit/TransitionTests.java
+++ b/src/test/java/com/pkb/unit/TransitionTests.java
@@ -1,8 +1,12 @@
 package com.pkb.unit;
 
+import static com.pkb.unit.Command.SHUTDOWN;
+import static com.pkb.unit.Command.START;
+import static com.pkb.unit.Command.STOP;
 import static com.pkb.unit.TestCommon.assertTracker;
 import static com.pkb.unit.message.ImmutableMessage.message;
 
+import org.junit.After;
 import org.junit.Test;
 
 import com.pkb.unit.message.Message;
@@ -11,6 +15,8 @@ import com.pkb.unit.message.payload.Transition;
 import io.reactivex.observers.TestObserver;
 
 public class TransitionTests {
+
+    private TestObserver<Message> testTransitionObserver;
 
     /**
      * START command should trigger the
@@ -26,7 +32,7 @@ public class TransitionTests {
         TestObserver<Message> testTransitionObserver = testTransitionObserver(bus);
 
         // WHEN
-        bus.sink().accept(command(unitID, Command.START));
+        bus.sink().accept(command(unitID, START));
 
         // THEN
         testTransitionObserver
@@ -55,7 +61,7 @@ public class TransitionTests {
         // WHEN
         unit1.addDependency(unit2ID);
 
-        bus.sink().accept(command(unit1ID, Command.START));
+        bus.sink().accept(command(unit1ID, START));
 
         testTransitionObserver
                 .awaitCount(3); // Should see 2 transitions
@@ -78,7 +84,7 @@ public class TransitionTests {
         // WHEN
         unit1.addDependency(unit2ID);
 
-        bus.sink().accept(command(unit1ID, Command.START));
+        bus.sink().accept(command(unit1ID, START));
         unit2.completeStart();
         unit1.completeStart();
 
@@ -86,6 +92,175 @@ public class TransitionTests {
                 .awaitCount(6);
 
         assertTracker(tracker);
+    }
+
+    // ccdaf8
+    @Test
+    public void whenSingleUnitAlreadyStartedThenStartDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        String unitID = "unit1";
+        FakeUnit unit1 = new FakeUnit(unitID, bus);
+        bus.sink().accept(command(unitID, START));
+        unit1.completeStart();
+
+        // WHEN
+        bus.sink().accept(command(unitID, START));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(3);
+        assertTracker(tracker);
+    }
+
+    // 5c4777
+    @Test
+    public void whenDependencyAlreadyStartedThenStartDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        String unit1ID = "unit1";
+        String unit2ID = "unit2";
+        FakeUnit unit1 = new FakeUnit(unit1ID, bus);
+        FakeUnit unit2 = new FakeUnit(unit2ID, bus);
+        unit1.addDependency(unit2ID);
+        bus.sink().accept(command(unit1ID, START));
+        unit2.completeStart();
+        unit1.completeStart();
+
+        // WHEN
+        bus.sink().accept(command(unit2ID, START));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(6);
+        assertTracker(tracker);
+    }
+
+    // ceb5f8
+    @Test
+    public void whenSingleUnitAlreadyStoppedThenStopDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        String unitID = "unit1";
+        FakeUnit unit1 = new FakeUnit(unitID, bus);
+        bus.sink().accept(command(unitID, START));
+        unit1.completeStart();
+        bus.sink().accept(command(unitID, STOP));
+        unit1.completeStop();
+
+        // WHEN
+        bus.sink().accept(command(unitID, STOP));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(5);
+        assertTracker(tracker);
+    }
+
+    // fe5fbb
+    @Test
+    public void whenDependencyAlreadyStoppedThenStopDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        String unit1ID = "unit1";
+        String unit2ID = "unit2";
+        FakeUnit unit1 = new FakeUnit(unit1ID, bus);
+        FakeUnit unit2 = new FakeUnit(unit2ID, bus);
+        unit1.addDependency(unit2ID);
+
+        // WHEN
+        bus.sink().accept(command(unit1ID, START));
+        unit2.completeStart();
+        unit1.completeStart();
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(6); // Make sure that START command arrives earlier than STOP
+
+        // WHEN
+        bus.sink().accept(command(unit2ID, STOP));
+        unit2.completeStop();
+        unit1.completeStop();
+        bus.sink().accept(command(unit2ID, STOP));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(11);
+        assertTracker(tracker);
+    }
+
+    // d392c3
+    @Test
+    public void whenSingleUnitAlreadyShutdownThenShutdownDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        String unitID = "unit1";
+        FakeUnit unit1 = new FakeUnit(unitID, bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        bus.sink().accept(command(unitID, START));
+        unit1.completeStart();
+        bus.sink().accept(command(unitID, STOP));
+        unit1.completeStop();
+        bus.sink().accept(command(unitID, SHUTDOWN));
+
+        // WHEN
+        bus.sink().accept(command(unitID, SHUTDOWN));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(5);
+        assertTracker(tracker);
+    }
+
+    // ddc205
+    @Test
+    public void whenDependencyAlreadyShutdownThenShutdownDoesNothing() throws Exception {
+        // GIVEN
+        Bus bus = new LocalBus();
+        Tracker tracker = new Tracker(bus);
+        testTransitionObserver = testTransitionObserver(bus);
+        String unit1ID = "unit1";
+        String unit2ID = "unit2";
+        FakeUnit unit1 = new FakeUnit(unit1ID, bus);
+        FakeUnit unit2 = new FakeUnit(unit2ID, bus);
+        unit1.addDependency(unit2ID);
+
+        // WHEN
+        bus.sink().accept(command(unit1ID, START));
+        unit2.completeStart();
+        unit1.completeStart();
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(6); // Make sure that START command arrives earlier than STOP
+
+        // WHEN
+        bus.sink().accept(command(unit2ID, STOP));
+        unit2.completeStop();
+        unit1.completeStop();
+        bus.sink().accept(command(unit2ID, SHUTDOWN));
+        bus.sink().accept(command(unit2ID, SHUTDOWN));
+
+        // THEN
+        testTransitionObserver
+                .awaitCount(11);
+        assertTracker(tracker);
+    }
+
+    @After
+    public void disposeTestObservers() {
+        if (testTransitionObserver != null && !testTransitionObserver.isDisposed()) {
+            testTransitionObserver.dispose();
+        }
     }
 
     private Message<Command> command(String targetUnitId, Command start) {

--- a/src/test/java/com/pkb/unit/da26d6/5c4777-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/5c4777-approved.content
@@ -1,0 +1,6 @@
+/*com.pkb.unit.TransitionTests.whenDependencyAlreadyStartedThenStartDoesNothing*/
+digraph { 
+unit1 [label="unit1 STARTED"]
+unit1 -> unit2
+unit2 [label="unit2 STARTED"]
+}

--- a/src/test/java/com/pkb/unit/da26d6/ccdaf8-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/ccdaf8-approved.content
@@ -1,0 +1,4 @@
+/*com.pkb.unit.TransitionTests.whenSingleUnitAlreadyStartedThenStartDoesNothing*/
+digraph { 
+unit1 [label="unit1 STARTED"]
+}

--- a/src/test/java/com/pkb/unit/da26d6/ceb5f8-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/ceb5f8-approved.content
@@ -1,0 +1,4 @@
+/*com.pkb.unit.TransitionTests.whenSingleUnitAlreadyStoppedThenStopDoesNothing*/
+digraph { 
+unit1 [label="unit1 STOPPED"]
+}

--- a/src/test/java/com/pkb/unit/da26d6/d392c3-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/d392c3-approved.content
@@ -1,0 +1,4 @@
+/*com.pkb.unit.TransitionTests.whenSingleUnitAlreadyShutdownThenShutdownDoesNothing*/
+digraph { 
+unit1 [label="unit1 SHUTDOWN"]
+}

--- a/src/test/java/com/pkb/unit/da26d6/ddc205-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/ddc205-approved.content
@@ -1,0 +1,6 @@
+/*com.pkb.unit.TransitionTests.whenDependencyAlreadyShutdownThenShutdownDoesNothing*/
+digraph { 
+unit1 [label="unit1 STOPPED"]
+unit1 -> unit2
+unit2 [label="unit2 SHUTDOWN"]
+}

--- a/src/test/java/com/pkb/unit/da26d6/fe5fbb-approved.content
+++ b/src/test/java/com/pkb/unit/da26d6/fe5fbb-approved.content
@@ -1,0 +1,6 @@
+/*com.pkb.unit.TransitionTests.whenDependencyAlreadyStoppedThenStopDoesNothing*/
+digraph { 
+unit1 [label="unit1 STOPPED"]
+unit1 -> unit2
+unit2 [label="unit2 STOPPED"]
+}


### PR DESCRIPTION
Based on the discussion from yesterday I have implemented the cases when a Unit gets a START/STOP command when it is already in STARTED/STOPPED state.

Now **it does no operation and sends a _Transition_ message** with a comment that "No operation executed". I am not sure if the _Transition_ is needed at all but maybe clients want to know about the result of their _Command_. **What do you think, is it needed?**