### PR TITLE
GDE-1387 Add retry capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+target/

--- a/src/main/java/com/pkb/unit/Command.java
+++ b/src/main/java/com/pkb/unit/Command.java
@@ -3,5 +3,5 @@ package com.pkb.unit;
 import java.io.Serializable;
 
 public enum Command implements Serializable {
-    START, STOP, ENABLE, DISABLE
+    START, STOP, ENABLE, DISABLE, CLEAR_DESIRED_STATE
 }

--- a/src/main/java/com/pkb/unit/Unit.java
+++ b/src/main/java/com/pkb/unit/Unit.java
@@ -79,7 +79,7 @@ public abstract class Unit {
             new StopHandler(),
             new EnableHandler(),
             new DisableHandler(),
-            new ClearDesiredState()
+            new ClearDesiredStateHandler()
     );
 
     private Map<String, Optional<State>> mandatoryDependencies = new ConcurrentHashMap<>();
@@ -337,7 +337,7 @@ public abstract class Unit {
         return id;
     }
 
-    private class ClearDesiredState implements CommandHandler {
+    private class ClearDesiredStateHandler implements CommandHandler {
         @Override
         public boolean handles(Command c) {
             return c == CLEAR_DESIRED_STATE;

--- a/src/test/java/com/pkb/unit/FakeUnit.java
+++ b/src/test/java/com/pkb/unit/FakeUnit.java
@@ -1,18 +1,22 @@
 package com.pkb.unit;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A fake
  */
 class FakeUnit extends Unit {
+    public static long RETRY_PERIOD = 1;
+    public static TimeUnit RETRY_PERIOD_UNIT = TimeUnit.SECONDS;
+
     private CountDownLatch cdlCompleteStart = new CountDownLatch(1);
     private CountDownLatch cdlCompleteStop = new CountDownLatch(1);
     private boolean shouldFailStart;
     private boolean shouldFailStop;
 
     public FakeUnit(String id, Bus owner) {
-        super(id, owner);
+        super(id, owner, RETRY_PERIOD, RETRY_PERIOD_UNIT);
     }
 
     @Override

--- a/src/test/java/com/pkb/unit/FakeUnit.java
+++ b/src/test/java/com/pkb/unit/FakeUnit.java
@@ -69,4 +69,12 @@ class FakeUnit extends Unit {
         shouldFailStop = true;
         cdlCompleteStop.countDown();
     }
+
+    /**
+     * Increase the visibility of this to public for testing.
+     */
+    @Override
+    public void failed() {
+        super.failed();
+    }
 }

--- a/src/test/java/com/pkb/unit/RetryTests.java
+++ b/src/test/java/com/pkb/unit/RetryTests.java
@@ -1,0 +1,117 @@
+package com.pkb.unit;
+
+import static com.pkb.unit.Command.DISABLE;
+import static com.pkb.unit.Command.ENABLE;
+import static com.pkb.unit.Command.START;
+import static com.pkb.unit.DesiredState.DISABLED;
+import static com.pkb.unit.DesiredState.ENABLED;
+import static com.pkb.unit.DesiredState.UNSET;
+import static com.pkb.unit.State.FAILED;
+import static com.pkb.unit.State.STARTED;
+import static com.pkb.unit.State.STARTING;
+import static com.pkb.unit.State.STOPPED;
+import static com.pkb.unit.tracker.ImmutableSystemState.systemState;
+import static com.pkb.unit.tracker.ImmutableUnit.unit;
+
+import org.junit.Test;
+
+public class RetryTests extends AbstractUnitTest {
+    @Test
+    public void noDesiredStateHasNoRetry() throws Exception {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        FakeUnit fakeUnit = new FakeUnit("unit1", bus);
+        bus.sink().accept(command("unit1", START));
+        fakeUnit.failStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(UNSET).withState(FAILED)
+        ).build());
+
+        // WHEN
+        testScheduler.advanceTimeBy(FakeUnit.RETRY_PERIOD + 1, FakeUnit.RETRY_PERIOD_UNIT);
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(UNSET).withState(FAILED)
+        ).build());
+    }
+
+    @Test
+    public void enabledUnitRetries() throws Exception {
+        // GIVEN
+        setupComputationTestScheduler();
+        setupIOTestScheduler();
+
+        // WHEN
+        FakeUnit fakeUnit = new FakeUnit("unit1", bus);
+        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.failStart();
+        testComputationScheduler.triggerActions();
+        testIOScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(FAILED)
+        ).build());
+
+        // WHEN
+        testComputationScheduler.advanceTimeBy(FakeUnit.RETRY_PERIOD + 1, FakeUnit.RETRY_PERIOD_UNIT);
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(STARTING)
+        ).build());
+    }
+
+    @Test
+    public void disabledUnitStops() throws Exception {
+        // GIVEN
+        setupComputationTestScheduler();
+        setupIOTestScheduler();
+
+        // WHEN
+        FakeUnit fakeUnit = new FakeUnit("unit1", bus);
+        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.completeStart();
+        testComputationScheduler.triggerActions();
+        testIOScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(STARTED)
+        ).build());
+
+        // WHEN
+        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.completeStop();
+        testComputationScheduler.triggerActions();
+        testIOScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(DISABLED).withState(STOPPED)
+        ).build());
+    }
+
+    @Test
+    public void disabledUnitWontStart() throws Exception {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        new FakeUnit("unit1", bus);
+        bus.sink().accept(command("unit1", DISABLE));
+        bus.sink().accept(command("unit1", START));
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(DISABLED).withState(STOPPED)
+        ).build());
+    }
+}

--- a/src/test/java/com/pkb/unit/RetryTests.java
+++ b/src/test/java/com/pkb/unit/RetryTests.java
@@ -1,5 +1,6 @@
 package com.pkb.unit;
 
+import static com.pkb.unit.Command.CLEAR_DESIRED_STATE;
 import static com.pkb.unit.Command.DISABLE;
 import static com.pkb.unit.Command.ENABLE;
 import static com.pkb.unit.Command.START;
@@ -112,6 +113,86 @@ public class RetryTests extends AbstractUnitTest {
         // THEN
         assertLatestState(systemState().addUnits(
                 unit("unit1").withDesiredState(DISABLED).withState(STOPPED)
+        ).build());
+    }
+
+    @Test
+    public void disabledReenableDependency() throws Exception {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        FakeUnit unit1 = new FakeUnit("unit1", bus);
+        FakeUnit unit2 = new FakeUnit("unit2", bus);
+        unit1.addDependency("unit2");
+        bus.sink().accept(command("unit1", ENABLE));
+        unit1.completeStart();
+        unit2.completeStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withState(STARTED).withDesiredState(ENABLED).withDependencies("unit2"),
+                unit("unit2").withState(STARTED).withDesiredState(UNSET)
+        ).build());
+
+        // WHEN
+        bus.sink().accept(command("unit2", DISABLE));
+        unit2.completeStop();
+        unit1.completeStop();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withState(STARTING).withDesiredState(ENABLED).withDependencies("unit2"),
+                unit("unit2").withState(STOPPED).withDesiredState(DISABLED)
+        ).build());
+
+        // WHEN
+        bus.sink().accept(command("unit2", CLEAR_DESIRED_STATE));
+        unit1.completeStart();
+        unit2.completeStart();
+        testScheduler.advanceTimeBy(FakeUnit.RETRY_PERIOD, FakeUnit.RETRY_PERIOD_UNIT);
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withState(STARTED).withDesiredState(ENABLED).withDependencies("unit2"),
+                unit("unit2").withState(STARTED).withDesiredState(UNSET)
+        ).build());
+    }
+
+    @Test
+    public void spontaneousFailureRetries() throws Exception {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        FakeUnit fakeUnit = new FakeUnit("unit1", bus);
+        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.completeStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(STARTED)
+        ).build());
+
+        // WHEN
+        fakeUnit.failed();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(FAILED)
+        ).build());
+
+        // WHEN
+        fakeUnit.completeStart();
+        testScheduler.advanceTimeBy(FakeUnit.RETRY_PERIOD + 1, FakeUnit.RETRY_PERIOD_UNIT);
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withDesiredState(ENABLED).withState(STARTED)
         ).build());
     }
 }


### PR DESCRIPTION
Added retry capability & tests, so units that are enabled or disabled will attempt to return to their desired state.