### PR TITLE
Prevent unit process stop when failed and retry to stop failed

### DIFF
--- a/src/main/java/com/pkb/unit/Unit.java
+++ b/src/main/java/com/pkb/unit/Unit.java
@@ -118,7 +118,7 @@ public abstract class Unit {
     private void handleRetry(Long ignored) {
         if (desiredState == ENABLED && state != STARTED) {
             sendCommand(id, START);
-        } else if (desiredState == DISABLED && state != STOPPED) {
+        } else if (desiredState == DISABLED && state != STOPPED && state != FAILED) {
             sendCommand(id, STOP);
         }
     }
@@ -276,6 +276,11 @@ public abstract class Unit {
 
             if (state == CREATED) {
                 setAndPublishState(STOPPED, "Never started.");
+                return;
+            }
+
+            if (state == FAILED) {
+                setAndPublishState(state, "FAILED unit cannot be stopped.");
                 return;
             }
 


### PR DESCRIPTION
This PR is intended to disable the transition of units from `FAILED` to `STOPPED` State.

As discussed [here](https://patientsknowbest.slack.com/archives/CL46Q3695/p1563534326047600) we won't deal with stopping units after they fail to stop except for bugs.