### PR TITLE
Gde 1088

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>bintray-patientsknowbest-patientsknowbest</id>
+            <username>mfashby</username>
+            <password>${env.BINTRAY_API_KEY}</password>
+        </server>
+    </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
 jdk:
   - openjdk8
+deploy:
+  provider: script
+  script: "mvn --settings .travis.settings.xml deploy"
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,13 @@ deploy:
   skip_cleanup: true
   on:
     all_branches: true
+
+addons:
+  sonarcloud:
+    organization: "patientsknowbest"
+    token:
+      secure: "fNYwfb+lU9rKWelBEJpE5LRxVXVzdx050n1ODGOJo4oIdtojjVxdT9GCt9ty4QQUWWpsbABx3/KCXaE4f6OnXd/HYPImaGFvWAhKM4NwtMW5jYwj5xFhyvLLcTxAEKr2ZVq6SdgfKIdKYRiWmARFIxbSBq4v+xAYWKBlVSsg05+/jK5JZ1AGJksbsaL4dgTkG9FcOf87cqgJ35s7HNxeNoMw96fLLMeAzUj1LgRaNG/2CtcerprYLADBlfYWRt0XOs50QHqSrj7aVlY9r6QxGhId8zQUQYek/7oB9cBTmKi2gkkRitMWrV+57t5yz6JW+676qs8klKabwRFO9klG/H380UP+CrfltTuk4Nznzt4qba1hq6Pq6GzqmHBOb1rYPSai8fBv8kn0nsArcb9O2UQRgQFgW/mWk9RGpAqYLMe/jfuFwp9kjXxHlYDrtSt/XZo+Cxc8FuS+GUulFCNMOhE6uPEWW4qrLs22OG1tBE+azlbuq/fr5+MEpFLyWQXKBn/jYFD73GjJMhyHxCPUDOsgmuRwVT4xT1NhrZqXLDNQRhLzQGwQmQ+mzjoo1RXQOwuAIbOO8UQKQ5xMu8Ly+j8DJGzEVbkavluFMkWHH4UQ3c3ugZgjsF4NZJjPwrM0kpmz84bqhvwo0KSXOrHVRjWf/qh2qKiLM51QtRH0/x8="
+
+script:
+  # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
+  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ deploy:
   provider: script
   script: "mvn --settings .travis.settings.xml deploy"
   skip_cleanup: true
+  on:
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,3 @@ deploy:
   provider: script
   script: "mvn --settings .travis.settings.xml deploy"
   skip_cleanup: true
-  on:
-    tags: true
-    all_branches: true

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
 
+    <profiles>
+        <!-- Use the current branch / tag as the version on CI -->
+        <profile>
+            <id>ci-build</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.TRAVIS_BRANCH</name>
+                </property>
+            </activation>
+            <properties>
+                <revision>${env.TRAVIS_BRANCH}</revision>
+            </properties>
+        </profile>
+    </profiles>
+
+
+    <modelVersion>4.0.0</modelVersion>
     <groupId>com.pkb</groupId>
     <artifactId>unit</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <properties>
         <immutables.version>2.7.4</immutables.version>
         <junit.version>4.12</junit.version>
@@ -15,6 +32,7 @@
         <rxrelay.version>2.1.0</rxrelay.version>
         <approvalcrest.version>0.21</approvalcrest.version>
         <guava.version>28.0-jre</guava.version>
+        <revision>0.0.0-SNAPSHOT</revision>
     </properties>
     <dependencies>
         <dependency>
@@ -87,4 +105,11 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <repository>
+            <id>bintray-patientsknowbest-patientsknowbest</id>
+            <name>patientsknowbest-patientsknowbest</name>
+            <url>https://api.bintray.com/maven/patientsknowbest/patientsknowbest/unit/;publish=1</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
[GDE-1088](https://pkbdev.atlassian.net/browse/GDE-1088)

Adds deployment to bintray (a free, public maven repository)
Note that TRAVIS_BRANCH is set to either the branch name or tag name, as documented [here](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)
Local builds will default to using 0.0.0-SNAPSHOT as the version (similar to other PKB libraries, useful in local development)