### PR TITLE
Added some convenience methods for controlling units.

### DIFF
--- a/src/main/java/com/pkb/unit/Unit.java
+++ b/src/main/java/com/pkb/unit/Unit.java
@@ -109,7 +109,8 @@ public abstract class Unit {
 
 
     /**
-     * @return true if this set did not already contain the specified element
+     * Adds a dependency to this unit.
+     * This unit can only start if all it's dependencies are started.
      */
     public void addDependency(String dependency) {
         mandatoryDependencies.put(dependency, Optional.empty());
@@ -122,7 +123,7 @@ public abstract class Unit {
     }
 
     /**
-     * @return true if this set contained the specified element
+     * Removes a dependency from this unit.
      */
     public void removeDependency(String dependency) {
         mandatoryDependencies.remove(dependency);

--- a/src/test/java/com/pkb/unit/AbstractUnitTest.java
+++ b/src/test/java/com/pkb/unit/AbstractUnitTest.java
@@ -2,7 +2,6 @@ package com.pkb.unit;
 
 import static com.github.karsaig.approvalcrest.MatcherAssert.assertThat;
 import static com.github.karsaig.approvalcrest.matcher.Matchers.sameBeanAs;
-import static com.pkb.unit.message.ImmutableMessage.message;
 import static java.util.stream.Collectors.joining;
 
 import java.util.ArrayList;
@@ -15,7 +14,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import com.pkb.unit.dot.DOT;
-import com.pkb.unit.message.Message;
 import com.pkb.unit.tracker.SystemState;
 import com.pkb.unit.tracker.Tracker;
 
@@ -77,11 +75,5 @@ public class AbstractUnitTest {
     protected void setupIOTestScheduler() {
         testIOScheduler = new TestScheduler();
         RxJavaPlugins.setIoSchedulerHandler(i -> testIOScheduler);
-    }
-
-    protected Message<Command> command(String targetUnitId, Command start) {
-        return message(Command.class)
-                .withTarget(targetUnitId)
-                .withPayload(start);
     }
 }

--- a/src/test/java/com/pkb/unit/DependencyTests.java
+++ b/src/test/java/com/pkb/unit/DependencyTests.java
@@ -1,10 +1,5 @@
 package com.pkb.unit;
 
-import static com.pkb.unit.Command.CLEAR_DESIRED_STATE;
-import static com.pkb.unit.Command.DISABLE;
-import static com.pkb.unit.Command.ENABLE;
-import static com.pkb.unit.Command.START;
-import static com.pkb.unit.Command.STOP;
 import static com.pkb.unit.DesiredState.DISABLED;
 import static com.pkb.unit.DesiredState.ENABLED;
 import static com.pkb.unit.DesiredState.UNSET;
@@ -439,7 +434,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -457,7 +452,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         unit2.completeStart();
         unit1.completeStart();
         testScheduler.triggerActions();
@@ -477,7 +472,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit2.completeStart();
         unit1.completeStart();
 
@@ -489,7 +484,7 @@ public class DependencyTests extends AbstractUnitTest {
                 unit("unit2").withDesiredState(UNSET).withState(STARTED)).build());
 
         // WHEN
-        bus.sink().accept(command("unit2", STOP));
+        unit2.stop();
         unit2.completeStop();
         unit1.completeStop();
         testScheduler.triggerActions();
@@ -500,7 +495,7 @@ public class DependencyTests extends AbstractUnitTest {
                 unit("unit2").withDesiredState(UNSET).withState(STOPPED)).build());
 
         // WHEN
-        bus.sink().accept(command("unit2", STOP));
+        unit2.stop();
         testScheduler.triggerActions();
 
         // THEN
@@ -518,8 +513,8 @@ public class DependencyTests extends AbstractUnitTest {
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
-        bus.sink().accept(command("unit1", START));
-        bus.sink().accept(command("unit2", START));
+        unit1.start();
+        unit2.start();
         unit1.failStart();
         unit2.failStart();
         testScheduler.triggerActions();
@@ -542,7 +537,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         unit1.failStart();
         unit2.completeStart();
         testScheduler.triggerActions();
@@ -563,7 +558,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit2.failStart();
         unit1.completeStart();
         testScheduler.triggerActions();
@@ -586,7 +581,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit3 = new FakeUnit("unit3", bus);
         unit1.addDependency("unit2");
         unit1.addDependency("unit3");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit2.failStart();
         unit3.completeStart();
 
@@ -612,7 +607,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit3 = new FakeUnit("unit3", bus);
         unit1.addDependency("unit2");
         unit2.addDependency("unit3");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit3.failStart();
         testScheduler.triggerActions();
 
@@ -632,7 +627,7 @@ public class DependencyTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testScheduler.triggerActions();
 
@@ -642,7 +637,7 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.failStop();
         testScheduler.triggerActions();
 
@@ -661,8 +656,8 @@ public class DependencyTests extends AbstractUnitTest {
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
-        bus.sink().accept(command("unit1", START));
-        bus.sink().accept(command("unit2", START));
+        unit1.start();
+        unit2.start();
         unit1.completeStart();
         unit2.completeStart();
         testScheduler.triggerActions();
@@ -674,8 +669,8 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
-        bus.sink().accept(command("unit2", STOP));
+        unit1.stop();
+        unit2.stop();
         unit1.failStop();
         unit2.failStop();
         testScheduler.triggerActions();
@@ -696,7 +691,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         unit2.completeStart();
         testScheduler.triggerActions();
@@ -708,7 +703,7 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit2", STOP));
+        unit2.stop();
         unit2.failStop();
         unit1.completeStop();
         testScheduler.triggerActions();
@@ -731,7 +726,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit3 = new FakeUnit("unit3", bus);
         unit1.addDependency("unit2");
         unit2.addDependency("unit3");
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit3.completeStart();
         unit2.completeStart();
         unit1.completeStart();
@@ -745,7 +740,7 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit3", STOP));
+        unit3.stop();
         unit3.failStop();
         unit2.completeStop();
         unit1.completeStop();
@@ -768,7 +763,7 @@ public class DependencyTests extends AbstractUnitTest {
         FakeUnit unit1 = new FakeUnit("unit1", bus);
         FakeUnit unit2 = new FakeUnit("unit2", bus);
         unit1.addDependency("unit2");
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         unit1.completeStart();
         unit2.completeStart();
         testScheduler.triggerActions();
@@ -780,7 +775,7 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit2", DISABLE));
+        unit2.disable();
         unit2.completeStop();
         unit1.completeStop();
         testScheduler.triggerActions();
@@ -792,7 +787,7 @@ public class DependencyTests extends AbstractUnitTest {
         ).build());
 
         // WHEN
-        bus.sink().accept(command("unit2", CLEAR_DESIRED_STATE));
+        unit2.clearDesiredState();
         unit1.completeStart();
         unit2.completeStart();
         testScheduler.advanceTimeBy(FakeUnit.RETRY_PERIOD, FakeUnit.RETRY_PERIOD_UNIT);

--- a/src/test/java/com/pkb/unit/FailedTransitionTests.java
+++ b/src/test/java/com/pkb/unit/FailedTransitionTests.java
@@ -1,10 +1,5 @@
 package com.pkb.unit;
 
-import static com.pkb.unit.Command.CLEAR_DESIRED_STATE;
-import static com.pkb.unit.Command.DISABLE;
-import static com.pkb.unit.Command.ENABLE;
-import static com.pkb.unit.Command.START;
-import static com.pkb.unit.Command.STOP;
 import static com.pkb.unit.DesiredState.DISABLED;
 import static com.pkb.unit.DesiredState.ENABLED;
 import static com.pkb.unit.DesiredState.UNSET;
@@ -36,7 +31,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -63,7 +58,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.failStart();
         testScheduler.triggerActions();
 
@@ -91,7 +86,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
         fakeUnit.failed();
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         testScheduler.triggerActions();
 
         // THEN
@@ -100,7 +95,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         testScheduler.triggerActions();
 
         // THEN
@@ -126,7 +121,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -153,7 +148,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.failStart();
         testScheduler.triggerActions();
 
@@ -181,7 +176,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
         fakeUnit.failed();
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         testScheduler.triggerActions();
 
         // THEN
@@ -190,7 +185,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         testScheduler.triggerActions();
 
         // THEN
@@ -216,7 +211,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         testScheduler.triggerActions();
 
         // THEN
@@ -242,7 +237,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         testScheduler.triggerActions();
 
         // THEN
@@ -260,7 +255,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
         fakeUnit.failed();
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         testScheduler.triggerActions();
 
         // THEN
@@ -269,7 +264,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         testScheduler.triggerActions();
 
         // THEN
@@ -297,7 +292,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -307,7 +302,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -337,7 +332,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -347,7 +342,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -377,7 +372,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -387,7 +382,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -428,7 +423,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -438,7 +433,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -468,7 +463,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -478,7 +473,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
 
@@ -507,7 +502,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -517,7 +512,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -547,7 +542,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -557,7 +552,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -587,7 +582,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -597,7 +592,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -638,7 +633,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -648,7 +643,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -678,7 +673,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
 
@@ -688,7 +683,7 @@ public class FailedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();

--- a/src/test/java/com/pkb/unit/FakeUnit.java
+++ b/src/test/java/com/pkb/unit/FakeUnit.java
@@ -20,7 +20,7 @@ class FakeUnit extends Unit {
     }
 
     @Override
-    HandleOutcome handleStart() {
+    protected HandleOutcome handleStart() {
         System.out.println(id() + " starting");
         try {
             cdlCompleteStart.await();
@@ -36,7 +36,7 @@ class FakeUnit extends Unit {
     }
 
     @Override
-    HandleOutcome handleStop() {
+    protected HandleOutcome handleStop() {
         System.out.println(id() + " stopping");
         try {
             cdlCompleteStop.await();

--- a/src/test/java/com/pkb/unit/StartedTransitionTests.java
+++ b/src/test/java/com/pkb/unit/StartedTransitionTests.java
@@ -1,10 +1,5 @@
 package com.pkb.unit;
 
-import static com.pkb.unit.Command.CLEAR_DESIRED_STATE;
-import static com.pkb.unit.Command.DISABLE;
-import static com.pkb.unit.Command.ENABLE;
-import static com.pkb.unit.Command.START;
-import static com.pkb.unit.Command.STOP;
 import static com.pkb.unit.DesiredState.DISABLED;
 import static com.pkb.unit.DesiredState.ENABLED;
 import static com.pkb.unit.DesiredState.UNSET;
@@ -27,7 +22,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testScheduler.triggerActions();
 
@@ -37,7 +32,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         testScheduler.triggerActions();
 
         // THEN
@@ -54,7 +49,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         unit1.completeStart();
         testScheduler.triggerActions();
 
@@ -64,7 +59,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         testScheduler.triggerActions();
 
         // THEN
@@ -81,7 +76,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testScheduler.triggerActions();
 
@@ -91,7 +86,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         testScheduler.triggerActions();
 
         // THEN
@@ -108,7 +103,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -118,7 +113,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testScheduler.triggerActions();
 
@@ -136,7 +131,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
         // THEN
@@ -145,7 +140,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.failStop();
         testScheduler.triggerActions();
 
@@ -164,7 +159,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -175,7 +170,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -207,7 +202,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -218,7 +213,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.failStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -249,7 +244,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -259,7 +254,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testScheduler.triggerActions();
 
@@ -277,7 +272,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -287,7 +282,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.failStop();
         testScheduler.triggerActions();
 
@@ -305,7 +300,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testScheduler.triggerActions();
 
@@ -315,7 +310,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         testScheduler.triggerActions();
 
         // THEN
@@ -333,7 +328,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -344,7 +339,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -354,7 +349,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -383,7 +378,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -394,7 +389,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -404,7 +399,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -435,7 +430,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -446,7 +441,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -456,7 +451,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -476,7 +471,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -487,7 +482,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -497,7 +492,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
         fakeUnit.completeStart();
@@ -517,7 +512,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -528,7 +523,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -538,7 +533,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
         fakeUnit.completeStart();
@@ -558,7 +553,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -569,7 +564,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -579,7 +574,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -608,7 +603,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -619,7 +614,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -629,7 +624,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        fakeUnit.start();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -658,7 +653,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -669,7 +664,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -679,7 +674,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        fakeUnit.disable();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -710,7 +705,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -721,7 +716,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -731,7 +726,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
 
@@ -760,7 +755,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -771,7 +766,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        fakeUnit.stop();
         fakeUnit.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -781,7 +776,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        fakeUnit.clearDesiredState();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
 
@@ -800,7 +795,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -811,7 +806,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -821,7 +816,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        unit1.enable();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -850,7 +845,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -861,7 +856,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -871,7 +866,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -891,7 +886,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -902,7 +897,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -912,7 +907,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        unit1.disable();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -932,7 +927,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -943,7 +938,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -953,7 +948,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -973,7 +968,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -984,7 +979,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStop();
         testComputationScheduler.triggerActions();
 
@@ -994,7 +989,7 @@ public class StartedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        unit1.clearDesiredState();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
 

--- a/src/test/java/com/pkb/unit/StoppedTransitionTests.java
+++ b/src/test/java/com/pkb/unit/StoppedTransitionTests.java
@@ -1,10 +1,5 @@
 package com.pkb.unit;
 
-import static com.pkb.unit.Command.CLEAR_DESIRED_STATE;
-import static com.pkb.unit.Command.DISABLE;
-import static com.pkb.unit.Command.ENABLE;
-import static com.pkb.unit.Command.START;
-import static com.pkb.unit.Command.STOP;
 import static com.pkb.unit.DesiredState.DISABLED;
 import static com.pkb.unit.DesiredState.ENABLED;
 import static com.pkb.unit.DesiredState.UNSET;
@@ -28,7 +23,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -59,7 +54,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit fakeUnit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        fakeUnit.enable();
         fakeUnit.failStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -86,7 +81,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", DISABLE));
+        unit.disable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -95,7 +90,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -113,7 +108,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -140,7 +135,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -166,7 +161,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", DISABLE));
+        unit.disable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -183,8 +178,8 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", DISABLE));
-        bus.sink().accept(command("unit1", STOP));
+        unit.disable();
+        unit.stop();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -201,7 +196,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", STOP));
+        unit.stop();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -218,7 +213,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        unit.clearDesiredState();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -236,7 +231,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -245,7 +240,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -265,7 +260,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -274,7 +269,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -294,7 +289,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -303,7 +298,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        unit.disable();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -334,7 +329,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -343,7 +338,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit.stop();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -374,7 +369,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -383,7 +378,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        unit.clearDesiredState();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -403,7 +398,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -411,7 +406,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .addUnits(unit("unit1").withState(STARTING).withDesiredState(UNSET))
                 .build());
         // WHEN
-        bus.sink().accept(command("unit1", ENABLE));
+        unit.enable();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -431,7 +426,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -439,7 +434,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .addUnits(unit("unit1").withState(STARTING).withDesiredState(UNSET))
                 .build());
         // WHEN
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         unit.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();
@@ -459,7 +454,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -467,7 +462,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .addUnits(unit("unit1").withState(STARTING).withDesiredState(UNSET))
                 .build());
         // WHEN
-        bus.sink().accept(command("unit1", DISABLE));
+        unit.disable();
         unit.completeStart();
         unit.completeStop(); // STOP of DISABLE command will be ignored until START has been finished
         testComputationScheduler.triggerActions();
@@ -498,7 +493,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -507,7 +502,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", STOP));
+        unit1.stop();
         unit1.completeStart();
         unit1.completeStop(); // will be ignored
         testComputationScheduler.triggerActions();
@@ -528,7 +523,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
 
         // WHEN
         FakeUnit unit1 = new FakeUnit("unit1", bus);
-        bus.sink().accept(command("unit1", START));
+        unit1.start();
         testComputationScheduler.triggerActions();
 
         // THEN
@@ -537,7 +532,7 @@ public class StoppedTransitionTests extends AbstractUnitTest {
                 .build());
 
         // WHEN
-        bus.sink().accept(command("unit1", CLEAR_DESIRED_STATE));
+        unit1.clearDesiredState();
         unit1.completeStart();
         testComputationScheduler.triggerActions();
         testIOScheduler.triggerActions();


### PR DESCRIPTION
Ordered public / protected methods in Unit
GDE-1399

This makes it a tiny bit easier to use (& somewhat hides the RxJava dependency from consumers of the library)