### PR TITLE
Added utility for tracking restarts of units.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-.idea/
+# Build artifacts
 target/
+
+# Intellij
+.idea/
+unit.iml
+
+# VS Code
+.classpath
+.factorypath
+.project
+.settings/
+settings.json
+.vscode/

--- a/src/test/java/com/pkb/unit/FakeUnit.java
+++ b/src/test/java/com/pkb/unit/FakeUnit.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A fake
  */
-class FakeUnit extends Unit {
+public class FakeUnit extends Unit {
     public static long RETRY_PERIOD = 1;
     public static TimeUnit RETRY_PERIOD_UNIT = TimeUnit.SECONDS;
 

--- a/src/test/java/com/pkb/unit/tracker/TrackerRestartTest.java
+++ b/src/test/java/com/pkb/unit/tracker/TrackerRestartTest.java
@@ -1,0 +1,71 @@
+package com.pkb.unit.tracker;
+
+import static com.pkb.unit.DesiredState.ENABLED;
+import static com.pkb.unit.State.STARTED;
+import static com.pkb.unit.tracker.ImmutableSystemState.systemState;
+import static com.pkb.unit.tracker.ImmutableUnit.unit;
+
+import org.junit.Test;
+
+import com.pkb.unit.AbstractUnitTest;
+import com.pkb.unit.FakeUnit;
+
+import io.reactivex.observers.TestObserver;
+
+public class TrackerRestartTest extends AbstractUnitTest {
+    @Test
+    public void restartTrackerEmitsWhenUnitIsRestarted() {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        FakeUnit unit1 = new FakeUnit("unit1", bus);
+        unit1.enable();
+        unit1.completeStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withState(STARTED).withDesiredState(ENABLED))
+                .build());
+
+        // WHEN
+        TestObserver<Boolean> testRestartedObserver = Tracker.unitRestarted(bus, "unit1").test();
+        unit1.stop();
+        unit1.completeStop();
+        unit1.start();
+        unit1.completeStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        testRestartedObserver.assertResult(true);
+    }
+
+    @Test
+    public void restartTrackerDoesntEmitWhenUnitFailsToRestart() {
+        // GIVEN
+        setupComputationAndIOTestScheduler();
+
+        // WHEN
+        FakeUnit unit1 = new FakeUnit("unit1", bus);
+        unit1.enable();
+        unit1.completeStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        assertLatestState(systemState().addUnits(
+                unit("unit1").withState(STARTED).withDesiredState(ENABLED))
+                .build());
+
+        // WHEN
+        TestObserver<Boolean> testRestartedObserver = Tracker.unitRestarted(bus, "unit1").test();
+        unit1.stop();
+        unit1.completeStop();
+        unit1.start();
+        unit1.failStart();
+        testScheduler.triggerActions();
+
+        // THEN
+        testRestartedObserver.assertEmpty();
+    }
+}


### PR DESCRIPTION
Allows users to observe the restarting of a unit. This is desirable in some cases e.g. when some external code triggers a unit to restart, and wants to ensure the system has restarted and returned to the desired state before proceeding.