### PR TITLE
Test case to show the Tracker issue

### DIFF
--- a/src/main/java/com/pkb/unit/tracker/Tracker.java
+++ b/src/main/java/com/pkb/unit/tracker/Tracker.java
@@ -33,6 +33,8 @@ public class Tracker {
     private Tracker() {}
 
     private static class RestartTracker implements ObservableSource<Boolean> {
+
+        private String id;
         private boolean hasStopped;
         private boolean hasStarted;
 
@@ -41,6 +43,7 @@ public class Tracker {
         private Observer<? super Boolean> observer;
 
         RestartTracker(Bus bus, String id) {
+            this.id = id;
             hasStopped = false;
             hasStarted = false;
             disposable = payloads(bus.events(), Transition.class, id)
@@ -48,6 +51,9 @@ public class Tracker {
         }
 
         private void onTransition(Transition x) {
+            if (!id.equals(x.unitId())) {
+                return;
+            }
             if (!hasStopped && x.current() == STOPPED) {
                 hasStopped = true;
             } else if (hasStopped && x.current() == STARTED) {

--- a/src/test/java/com/pkb/unit/tracker/TrackerRestartTest.java
+++ b/src/test/java/com/pkb/unit/tracker/TrackerRestartTest.java
@@ -4,13 +4,18 @@ import static com.pkb.unit.DesiredState.ENABLED;
 import static com.pkb.unit.State.STARTED;
 import static com.pkb.unit.tracker.ImmutableSystemState.systemState;
 import static com.pkb.unit.tracker.ImmutableUnit.unit;
+import static junit.framework.TestCase.fail;
 
+import com.pkb.unit.Bus;
+import com.pkb.unit.LocalBus;
 import org.junit.Test;
 
 import com.pkb.unit.AbstractUnitTest;
 import com.pkb.unit.FakeUnit;
 
 import io.reactivex.observers.TestObserver;
+
+import java.util.concurrent.TimeUnit;
 
 public class TrackerRestartTest extends AbstractUnitTest {
     @Test
@@ -67,5 +72,77 @@ public class TrackerRestartTest extends AbstractUnitTest {
 
         // THEN
         testRestartedObserver.assertEmpty();
+    }
+
+    class TestUnit extends com.pkb.unit.Unit {
+
+        private String UNIT_ID;
+        private boolean delayStartup;
+
+        public TestUnit(Bus bus, String unitId, boolean delayStartup) {
+            super(unitId, bus, 1, TimeUnit.SECONDS);
+            UNIT_ID = unitId;
+            this.delayStartup = delayStartup;
+        }
+
+        @Override
+        protected synchronized com.pkb.unit.Unit.HandleOutcome handleStart() {
+            System.out.println(UNIT_ID + " handleStart()");
+            if (delayStartup) {
+                try {
+                    System.out.println("before wait");
+                    wait(2000L);
+                    System.out.println("after wait");
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            return com.pkb.unit.Unit.HandleOutcome.SUCCESS;
+        }
+
+        @Override
+        protected com.pkb.unit.Unit.HandleOutcome handleStop() {
+            System.out.println(UNIT_ID + " handleStop()");
+            return com.pkb.unit.Unit.HandleOutcome.SUCCESS;
+        }
+
+        public void failed() {
+            super.failed();
+        }
+
+        public String getUnitId() { return UNIT_ID;}
+    }
+
+    @Test
+    public synchronized void restartTrackerWithNestedUnitsWitDelay() {
+        // GIVEN
+        LocalBus bus = new LocalBus();
+        TestUnit unit1 = new TestUnit(bus, "unit1", false);
+        TestUnit unit2 = new TestUnit(bus, "unit2", true);
+        TestUnit unit3 = new TestUnit(bus, "unit3", false);
+        TestUnit unit4 = new TestUnit(bus, "unit4", false);
+        unit1.addDependency(unit2.getUnitId());
+        unit2.addDependency(unit3.getUnitId());
+        unit3.addDependency(unit4.getUnitId());
+        unit1.enable();
+        TestObserver<Boolean> testRestartedObserver = Tracker.unitRestarted(bus, unit1.getUnitId()).test();
+
+        // WHEN
+        unit2.failed();
+
+        // THEN
+        testRestartedObserver.awaitCount(1);
+        testRestartedObserver.assertResult(true);
+        System.out.println("finished");
+
+        try {
+            System.out.println("before wait");
+            wait(2000L);
+            System.out.println("after wait");
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        fail("Look at the system output ... the 'finished' comes before `unit1 handleStart()");
+
     }
 }


### PR DESCRIPTION
This is to show the RestartTracker issue.
Look at the test TrackerRestartTest.restartTrackerWithNestedUnitsWitDelay()

I dont know how to write the test for the failure properly ... but from the system output it is clear that 'finished' comes before `unit1 handleStart()` ... when the restart tracker should have blocked me until the system had restarted.