### PR TITLE
Make ID public. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <approvalcrest.version>0.21</approvalcrest.version>
         <guava.version>28.0-jre</guava.version>
         <revision>0.0.0-SNAPSHOT</revision>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -102,6 +103,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/pkb/unit/Unit.java
+++ b/src/main/java/com/pkb/unit/Unit.java
@@ -180,10 +180,10 @@ public abstract class Unit {
     }
 
     /**
-     * Access the ID of this unit
+     * Access the ID of this unit.
      * @return the unique identifier for the unit
      */
-    protected String id() {
+    public String id() {
         return id;
     }
 


### PR DESCRIPTION
This is reasonably safe, as unlike the state it doesn't need to be tracked remotely.

If you know the ID, it's never going to change underneath you. It's also handy to be able to access it in case you are e.g. tracking a bunch of specific units